### PR TITLE
Added dubbed video as a output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,11 @@ htmlcov/
 
 # Data and outputs
 data/
-*.mp3
-*.mp4
-*.vtt
+*_dub.mp4
+*_dub.mp3
+# Keep test data
+!tests/data/
+!tests/data/**
 
 # OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -75,10 +75,16 @@ python -m dubber --data-dir data --video video_name
 ```
 
 This will:
+- Load the original video from `data/video_name/video_name.mp4`
 - Read the VTT subtitles from `data/video_name/video_name.vtt`
 - Generate speech for each subtitle using OpenAI's TTS API (model: gpt-4o-mini-tts, voice: coral)
-- Preserve the original timing from the VTT file
-- Create a dubbed audio file at `data/video_name/video_name_dub.mp3`
+- Mute the original audio during subtitle timings
+- Overlay the generated speech at the correct times
+- Create two output files:
+  - `data/video_name/video_name_dub.mp4` - Dubbed video with synchronized audio
+  - `data/video_name/video_name_dub.mp3` - Dubbed audio track separately
+
+The output video retains the original soundtrack, but mutes it during dubbed phrases, creating a seamless viewing experience. The separate audio file contains the complete dubbed soundtrack.
 
 ### With voice configuration (future feature):
 ```bash

--- a/dubber/dubber.py
+++ b/dubber/dubber.py
@@ -3,11 +3,13 @@ import asyncio
 import io
 import os
 from pathlib import Path
+import tempfile
 
 import webvtt
 from dotenv import load_dotenv
 from openai import AsyncOpenAI
 from pydub import AudioSegment
+from moviepy import VideoFileClip, AudioFileClip, CompositeAudioClip
 
 
 async def text_to_speech(client, text, voice="coral", model="gpt-4o-mini-tts"):
@@ -21,6 +23,129 @@ async def text_to_speech(client, text, voice="coral", model="gpt-4o-mini-tts"):
         response_format="mp3"
     )
     return response.content
+
+
+def create_dubbed_video(video_path, captions, tts_segments, output_video_path, output_audio_path):
+    """
+    Creates a dubbed video by muting original audio during captions and overlaying TTS.
+    Also exports the dubbed audio as a separate file.
+    
+    Args:
+        video_path: Path to the original video file
+        captions: List of WebVTT caption objects
+        tts_segments: List of tuples (start_time, end_time, audio_data)
+        output_video_path: Path for the output video file
+        output_audio_path: Path for the output audio file
+    """
+    print(f"Loading video from {video_path}")
+    video = VideoFileClip(str(video_path))
+    
+    # Get the original audio
+    original_audio = video.audio
+    
+    # Create a modified audio track
+    # We'll work with the audio as an array and mute sections
+    audio_duration = video.duration
+    
+    # Export original audio to work with it
+    with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as temp_original:
+        original_audio.write_audiofile(temp_original.name)
+        original_audio_segment = AudioSegment.from_mp3(temp_original.name)
+    
+    # Create a copy of the original audio that we'll modify
+    modified_audio = original_audio_segment
+    
+    # Process each TTS segment
+    audio_clips = []
+    temp_files = []  # Keep track of temporary files for cleanup
+    
+    try:
+        for i, (start_time, end_time, audio_data) in enumerate(tts_segments):
+            # Convert times to milliseconds
+            start_ms = int(start_time * 1000)
+            end_ms = int(end_time * 1000)
+            
+            # Create TTS audio segment
+            tts_segment = AudioSegment.from_file(io.BytesIO(audio_data), format="mp3")
+            
+            # Mute the original audio during this caption
+            # Split the audio into three parts: before, during, and after
+            before = modified_audio[:start_ms]
+            during = AudioSegment.silent(duration=(end_ms - start_ms))
+            after = modified_audio[end_ms:]
+            
+            # Combine the parts
+            modified_audio = before + during + after
+            
+            # Save TTS segment to temporary file for moviepy
+            with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as temp_tts:
+                tts_segment.export(temp_tts.name, format="mp3")
+                temp_files.append(temp_tts.name)
+                # Create audio clip positioned at the right time
+                tts_clip = AudioFileClip(temp_tts.name).with_start(start_time)
+                audio_clips.append(tts_clip)
+    
+        # Export modified original audio
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as temp_modified:
+            modified_audio.export(temp_modified.name, format="mp3")
+            temp_files.append(temp_modified.name)
+            modified_audio_clip = AudioFileClip(temp_modified.name)
+        
+        # Combine all audio clips
+        final_audio = CompositeAudioClip([modified_audio_clip] + audio_clips)
+        
+        # Set the new audio to the video
+        final_video = video.with_audio(final_audio)
+        
+        # Write the output video
+        print(f"Writing dubbed video to {output_video_path}")
+        final_video.write_videofile(
+            str(output_video_path),
+            codec='libx264',
+            audio_codec='aac'
+        )
+        
+        # Export the dubbed audio separately
+        print(f"Writing dubbed audio to {output_audio_path}")
+        final_audio.write_audiofile(str(output_audio_path))
+        
+    finally:
+        # Clean up - ensure all resources are closed and temp files deleted
+        try:
+            video.close()
+        except:
+            pass
+        
+        try:
+            if 'final_video' in locals():
+                final_video.close()
+        except:
+            pass
+        
+        try:
+            if 'final_audio' in locals():
+                final_audio.close()
+        except:
+            pass
+        
+        # Close all audio clips
+        for clip in audio_clips:
+            try:
+                clip.close()
+            except:
+                pass
+        
+        # Delete all temporary files
+        try:
+            os.unlink(temp_original.name)
+        except:
+            pass
+        
+        for temp_file in temp_files:
+            try:
+                os.unlink(temp_file)
+            except:
+                pass
 
 
 async def main():
@@ -45,40 +170,43 @@ async def main():
         print(f"Error: Video directory not found at {video_dir}")
         return
 
+    # Check for required files
+    video_path = video_dir / f"{video_name}.mp4"
     vtt_path = video_dir / f"{video_name}.vtt"
+    output_video_path = video_dir / f"{video_name}_dub.mp4"
+    output_audio_path = video_dir / f"{video_name}_dub.mp3"
+
+    if not video_path.exists():
+        print(f"Error: Video file not found at {video_path}")
+        return
 
     if not vtt_path.exists():
         print(f"Error: VTT file not found at {vtt_path}")
         return
 
-    output_path = video_dir / f"{video_name}_dub.mp3"
+    print(f"Processing video: {video_name}")
+    print(f"Reading captions from: {vtt_path}")
 
     client = AsyncOpenAI()
-
     captions = webvtt.read(vtt_path)
-    combined_audio = AudioSegment.empty()
-    last_end_time = 0
-
-    for caption in captions:
-        start_time_ms = caption.start_in_seconds * 1000
-        end_time_ms = caption.end_in_seconds * 1000
-
-        # Add silence before the caption if needed
-        silence_duration = start_time_ms - last_end_time
-        if silence_duration > 0:
-            combined_audio += AudioSegment.silent(duration=silence_duration)
-
-        print(f"Generating audio for: {caption.text}")
+    
+    # Generate TTS for each caption
+    tts_segments = []
+    
+    for i, caption in enumerate(captions):
+        print(f"Generating TTS {i+1}/{len(captions)}: {caption.text}")
         audio_data = await text_to_speech(client, caption.text)
-
-        segment_audio = AudioSegment.from_file(io.BytesIO(audio_data), format="mp3")
-        combined_audio += segment_audio
-
-        last_end_time = end_time_ms
-
-    combined_audio.export(output_path, format="mp3")
-
-    print(f"Dubbed audio saved to {output_path}")
+        tts_segments.append((
+            caption.start_in_seconds,
+            caption.end_in_seconds,
+            audio_data
+        ))
+    
+    # Create the dubbed video and audio
+    create_dubbed_video(video_path, captions, tts_segments, output_video_path, output_audio_path)
+    
+    print(f"✅ Dubbed video saved to {output_video_path}")
+    print(f"✅ Dubbed audio saved to {output_audio_path}")
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 yt-dlp>=2024.4.10
 ffmpeg-python>=0.2.0
-moviepy>=1.0.3
+moviepy>=2.2.1
 youtube-transcript-api>=0.6.2
 openai-whisper>=20230314
 pytest>=8.1.0

--- a/tests/test_dubber.py
+++ b/tests/test_dubber.py
@@ -50,9 +50,12 @@ def test_dubber_integration():
         pytest.skip(f"VTT file not found at {vtt_path}. Run test_video_preparer first.")
     
     # Clean up any previous dubber output
-    output_path = video_dir / f"{VIDEO_NAME}_dub.mp3"
-    if output_path.exists():
-        output_path.unlink()
+    output_video_path = video_dir / f"{VIDEO_NAME}_dub.mp4"
+    output_audio_path = video_dir / f"{VIDEO_NAME}_dub.mp3"
+    if output_video_path.exists():
+        output_video_path.unlink()
+    if output_audio_path.exists():
+        output_audio_path.unlink()
     
     cmd = [
         sys.executable,
@@ -97,13 +100,35 @@ def test_dubber_integration():
         f"Output:\n{full_output}"
     )
 
-    # Check that the dubbed audio file was created
-    assert output_path.exists(), f"Dubbed audio file was not created at {output_path}"
+    # Check that both output files were created
+    assert output_video_path.exists(), f"Dubbed video file was not created at {output_video_path}"
+    assert output_audio_path.exists(), f"Dubbed audio file was not created at {output_audio_path}"
     
-    # Check that the file has some size (not empty)
-    file_size = output_path.stat().st_size
-    assert file_size > 1000, f"Dubbed audio file seems too small: {file_size} bytes"
+    # Check video file size
+    video_size = output_video_path.stat().st_size
+    assert video_size > 10000, f"Dubbed video file seems too small: {video_size} bytes"
     
-    print(f"✅ Successfully created dubbed audio:")
-    print(f"   🎵 File: {output_path.name}")
-    print(f"   📏 Size: {file_size:,} bytes") 
+    # Check audio file size
+    audio_size = output_audio_path.stat().st_size
+    assert audio_size > 1000, f"Dubbed audio file seems too small: {audio_size} bytes"
+    
+    # Verify it's a valid video file by checking with moviepy
+    try:
+        from moviepy import VideoFileClip
+        video = VideoFileClip(str(output_video_path))
+        duration = video.duration
+        has_audio = video.audio is not None
+        video.close()
+        
+        assert duration > 0, "Dubbed video has no duration"
+        assert has_audio, "Dubbed video has no audio track"
+        
+        print(f"✅ Successfully created dubbed outputs:")
+        print(f"   🎬 Video file: {output_video_path.name}")
+        print(f"   📏 Video size: {video_size:,} bytes")
+        print(f"   🎵 Audio file: {output_audio_path.name}")
+        print(f"   📏 Audio size: {audio_size:,} bytes")
+        print(f"   ⏱️  Duration: {duration:.1f} seconds")
+        print(f"   🔊 Has audio: {has_audio}")
+    except Exception as e:
+        pytest.fail(f"Failed to verify video file: {e}") 


### PR DESCRIPTION
### TL;DR

Enhanced video dubbing functionality to create complete dubbed videos with synchronized audio, not just audio files.

### What changed?

- Updated the dubber to create both a dubbed video file and a separate audio file
- Implemented a new `create_dubbed_video` function that:
  - Mutes the original audio during subtitle timings
  - Overlays the generated speech at the correct times
  - Preserves the original audio between dubbed segments
- Updated `.gitignore` to keep test data while ignoring output files
- Updated README to document the new output formats and functionality
- Upgraded moviepy dependency to version 2.2.1
- Enhanced tests to verify both video and audio outputs

### How to test?

1. Place a video file at `data/video_name/video_name.mp4`
2. Ensure you have a subtitle file at `data/video_name/video_name.vtt`
3. Run the dubber:
   ```bash
   python -m dubber --data-dir data --video video_name
   ```
4. Verify two output files are created:
   - `data/video_name/video_name_dub.mp4` - Dubbed video with synchronized audio
   - `data/video_name/video_name_dub.mp3` - Dubbed audio track separately

### Why make this change?

The previous implementation only created an audio file, requiring users to manually combine it with the original video. This enhancement provides a complete end-to-end solution that creates a properly dubbed video with the original audio muted during dubbed segments, creating a more seamless viewing experience while still providing the separate audio file for flexibility.